### PR TITLE
fix(plugins): preserve plugin data storage upon update

### DIFF
--- a/src/js/pluginManager.js
+++ b/src/js/pluginManager.js
@@ -397,8 +397,9 @@ export class PluginManager {
                 description: meta.description || '',
                 permissions: permissions,
                 script: scriptContent,
-                enabled: true,
-                installedAt: Date.now()
+                enabled: existingPlugin ? existingPlugin.enabled : true,
+                installedAt: existingPlugin ? existingPlugin.installedAt : Date.now(),
+                ...(existingPlugin && existingPlugin.storage ? { storage: existingPlugin.storage } : {})
             };
 
             const tx = this.dataService.db.transaction('plugins', 'readwrite');


### PR DESCRIPTION
This PR addresses an issue where updating a plugin deletes all of its associated data.

**🎯 What:**
Modified `src/js/pluginManager.js` -> `installPlugin` to selectively merge the `.storage`, `.enabled`, and `.installedAt` keys from the `existingPlugin` database entry.

**⚠️ Risk:**
Low. Uses standard short-circuit evaluations, and if `existingPlugin` is null, behavior defaults cleanly back to fresh install logic without affecting the overall application.

**🛡️ Solution:**
Spread `existingPlugin.storage` onto the new `pluginData` object before performing the IndexedDB `put()` action so the `PluginStorage` wrapper correctly reads it on the next load.

---
*PR created automatically by Jules for task [13197435463561854269](https://jules.google.com/task/13197435463561854269) started by @ADT109119*