### PR TITLE
修復: 明細頁面無法搜尋備註的問題

### DIFF
--- a/src/js/recordsList.js
+++ b/src/js/recordsList.js
@@ -250,9 +250,9 @@ export class RecordsListManager {
         if (this.filters.searchQuery) {
             const query = this.filters.searchQuery;
             baseFilteredRecords = baseFilteredRecords.filter(r => {
-                const noteMatch = r.note && r.note.toLowerCase().includes(query);
+                const descriptionMatch = r.description && r.description.toLowerCase().includes(query);
                 const amountMatch = r.amount.toString().includes(query);
-                return noteMatch || amountMatch;
+                return descriptionMatch || amountMatch;
             });
         }
 


### PR DESCRIPTION
**What**
Fixed a bug where searching records by note did not work on the detail page. 

**Why**
The previous implementation attempted to filter on `record.note`, but the record schema uses the `description` field for storing transaction notes.

**Verification**
Verified that `record.description` is the correct field used throughout the application to store notes. The change is isolated to the search filter array logic in `src/js/recordsList.js` and correctly replaces `r.note` with `r.description`.

**Result**
Users can now successfully search for transaction records by entering text that matches the record's notes.

---
*PR created automatically by Jules for task [9645024353450299652](https://jules.google.com/task/9645024353450299652) started by @ADT109119*